### PR TITLE
Create content-provenance.md

### DIFF
--- a/content-provenance.md
+++ b/content-provenance.md
@@ -1,0 +1,34 @@
+# Data Request content provenance
+
+## Tables
+| Table | Original source | Has data changed from the source for DReq v1.2.2? | Source for v1.2.2 content | Planned source for v1.2.3 content |
+|-------|-----------------|--------------------------------------------------|---------------------------|-----------------------------------|
+| Opportunity | CMIP7-DReq public consultation | No | Dreq-CMIP7 v1.2.2 | Dreq-CMIP7 v1.2.3 |
+| Variable Group | CMIP7-DReq public consultation | No | Dreq-CMIP7 v1.2.2 | Dreq-CMIP7 v1.2.3 |
+| Variables | CMIP6-DReq v.1.0.33, CMOR Variables | Yes, variable metadata updated and new variables added | Dreq-CMIP7 v1.2.2 | Dreq-CMIP7 v1.2.3 |
+| Experiment Group | CMIP7-DReq public consultation | No | Dreq-CMIP7 v1.2.2 | Dreq-CMIP7 v1.2.3 |
+| Physical Parameters | CMIP6-DReq v.1.0.33, MIP variables | Yes, variable metadata updated and new variables added | Dreq-CMIP7 v1.2.2 | Metadata will primarily come from the Variable Register |
+| MIPs | CMIP IPO Registered MIP database | No | Dreq-CMIP7 v1.2.2 | CMIP7 CVs, activity |
+| Data Request Themes | Data Request Task Team meeting decision | No | Dreq-CMIP7 v1.2.2 | Dreq-CMIP7 v1.2.3 |
+| Priority Level | Data Request Task Team | Yes, definitions updated and ‘Core’ Priority added during CMIP7-DReq public consultation | Dreq-CMIP7 v1.2.2 | Dreq-CMIP7 v1.2.3 |
+| Docs for Opportunities | CMIP7-DReq public consultation | No | Dreq-CMIP7 v1.2.2 | Dreq-CMIP7 v1.2.3 |
+| Time Subset | CMIP6-DReq v.1.0.33, Time slices | Yes, definitions updated to match CMIP7 experiment requirements during CMIP7-DReq public consultation | Dreq-CMIP7 v1.2.2 | Dreq-CMIP7 v1.2.3 |
+| Glossary | CMIP7-DReq public consultation | No | Dreq-CMIP7 v1.2.2 | Dreq-CMIP7 v1.2.3 |
+| Modelling Realm | CMIP6 CVs, v6.2.58 | No | Dreq-CMIP7 v1.2.2 | CMIP7 CVs, realm |
+| CMIP6 Frequency (legacy) | CMIP6 CVs, v6.2.58 | No | CMIP6 CVs, v6.2.58 | CMIP6 CVs, v6.2.58 |
+| CMIP7 Frequency | During a WIP meeting, it was agreed to reduce the list of frequencies for CMIP7 | No | Dreq-CMIP7 v1.2.2 | CMIP7 CVs, frequency |
+| CMIP6 Table Identifiers (legacy) | CMIP6 CVs, v6.2.58 | Yes, minor updates during the public consultation | Dreq-CMIP7 v1.2.2 | Dreq-CMIP7 v1.2.3 |
+| Spatial Shape | CMIP6 CVs, v6.2.58 | Yes, minor updates and additions during the public consultation | Dreq-CMIP7 v1.2.2 | Dreq-CMIP7 v1.2.3 |
+| Temporal Shape | CMIP6 CVs, v6.2.58 | Yes, minor updates and additions during the public consultation | Dreq-CMIP7 v1.2.2 | Dreq-CMIP7 v1.2.3 |
+| Cell Methods | CMIP6 CVs, v6.2.58 | Yes, minor updates and additions during the public consultation | Dreq-CMIP7 v1.2.2 | Variable register |
+| Cell Measures | CMIP6 CVs, v6.2.58 | Yes, minor updates and additions during the public consultation | Dreq-CMIP7 v1.2.2 | Variable register |
+| Coordinates and Dimensions | CMIP6 CVs, v6.2.58 | Yes, minor updates and additions during the public consultation | Dreq-CMIP7 v1.2.2 | Variable register |
+| Ranking | Baseline Climate Variables process | No | Baseline Climate Variables process | Baseline Climate Variables process |
+| CF Standard Names | ? | Yes, new versions pulled in periodically | Dreq-CMIP7 v1.2.2, compatible with CF Standard Name Table v91 | Dreq-CMIP7 v1.2.3, compatible with CF Standard Name Table v91 |
+| ESM-BCV 1.4 | Baseline Climate Variables process | No | Baseline Climate Variables process | Baseline Climate Variables process |
+
+## Additional sources
+| Item | Original source | Has data changed from the source for DReq v1.2.2? | Source for v1.2.2 content | Planned source for v1.2.3 content |
+|------|----------------|---------------------------------------------------|---------------------------|-----------------------------------|
+| CF area types |  |  |  |  |
+| Region | ? | Yes, discussion with CVs TT on [GitHub](https://github.com/WCRP-CMIP/CMIP7-CVs/issues/194) | Dreq-CMIP7 v1.2.2 | CMIP7 CVs, region |

--- a/content-provenance.md
+++ b/content-provenance.md
@@ -5,16 +5,17 @@
 |-------|-----------------|--------------------------------------------------|---------------------------|-----------------------------------|
 | Opportunity | CMIP7-DReq public consultation | No | Dreq-CMIP7 v1.2.2 | Dreq-CMIP7 v1.2.3 |
 | Variable Group | CMIP7-DReq public consultation | No | Dreq-CMIP7 v1.2.2 | Dreq-CMIP7 v1.2.3 |
-| Variables | CMIP6-DReq v.1.0.33, CMOR Variables | Yes, variable metadata updated and new variables added | Dreq-CMIP7 v1.2.2 | Dreq-CMIP7 v1.2.3 |
+| Variables | CMIP6-DReq v.1.0.33, CMOR Variables | Yes, variable metadata updated and new variables added | Dreq-CMIP7 v1.2.2 | Some metadata (as outlined in other rows of this table) will come from the Variable Registry. The source of other metadata will be the Dreq-CMIP7 v1.2.3 |
 | Experiment Group | CMIP7-DReq public consultation | No | Dreq-CMIP7 v1.2.2 | Dreq-CMIP7 v1.2.3 |
-| Physical Parameters | CMIP6-DReq v.1.0.33, MIP variables | Yes, variable metadata updated and new variables added | Dreq-CMIP7 v1.2.2 | Metadata will primarily come from the Variable Register |
+| Physical Parameters | CMIP6-DReq v.1.0.33, MIP variables | Yes, variable metadata updated and new variables added | Dreq-CMIP7 v1.2.2 | Some metadata (namely root names, units, and CF names) will come from the Variable Registry. The source of other metadata will be the Dreq-CMIP7 v1.2.3 |
+| Experiments | CMIP IPO list of CMIP7 Assessment Fast Track experiments, as agreed by CMIP Panel | Yes, additional experiments added and AFT list altered | Dreq-CMIP7 v1.2.2 | CMIP7 CVs, experiments |
 | MIPs | CMIP IPO Registered MIP database | No | Dreq-CMIP7 v1.2.2 | CMIP7 CVs, activity |
 | Data Request Themes | Data Request Task Team meeting decision | No | Dreq-CMIP7 v1.2.2 | Dreq-CMIP7 v1.2.3 |
 | Priority Level | Data Request Task Team | Yes, definitions updated and ‘Core’ Priority added during CMIP7-DReq public consultation | Dreq-CMIP7 v1.2.2 | Dreq-CMIP7 v1.2.3 |
 | Docs for Opportunities | CMIP7-DReq public consultation | No | Dreq-CMIP7 v1.2.2 | Dreq-CMIP7 v1.2.3 |
 | Time Subset | CMIP6-DReq v.1.0.33, Time slices | Yes, definitions updated to match CMIP7 experiment requirements during CMIP7-DReq public consultation | Dreq-CMIP7 v1.2.2 | Dreq-CMIP7 v1.2.3 |
 | Glossary | CMIP7-DReq public consultation | No | Dreq-CMIP7 v1.2.2 | Dreq-CMIP7 v1.2.3 |
-| Modelling Realm | CMIP6 CVs, v6.2.58 | No | Dreq-CMIP7 v1.2.2 | CMIP7 CVs, realm |
+| Modelling Realm | CMIP6 CVs, v6.2.58 | No | CMIP6 CVs, v6.2.58 | CMIP7 CVs, realm |
 | CMIP6 Frequency (legacy) | CMIP6 CVs, v6.2.58 | No | CMIP6 CVs, v6.2.58 | CMIP6 CVs, v6.2.58 |
 | CMIP7 Frequency | During a WIP meeting, it was agreed to reduce the list of frequencies for CMIP7 | No | Dreq-CMIP7 v1.2.2 | CMIP7 CVs, frequency |
 | CMIP6 Table Identifiers (legacy) | CMIP6 CVs, v6.2.58 | Yes, minor updates during the public consultation | Dreq-CMIP7 v1.2.2 | Dreq-CMIP7 v1.2.3 |
@@ -32,3 +33,4 @@
 |------|----------------|---------------------------------------------------|---------------------------|-----------------------------------|
 | CF area types |  |  |  |  |
 | Region | ? | Yes, discussion with CVs TT on [GitHub](https://github.com/WCRP-CMIP/CMIP7-CVs/issues/194) | Dreq-CMIP7 v1.2.2 | CMIP7 CVs, region |
+| Branded variable names  | [Branded variable mapper code v0.9.0](https://github.com/znicholls/CMIP-branded-variable-mapper) with input data as defined in [this spreadsheet](https://docs.google.com/spreadsheets/d/1VBIcauiQPZEN1wdkOLpwBDCCh46QavWzQi7D2aDKK_8/edit), columns DK, DL, DN | No | [Branded variable mapper code v0.9.0](https://github.com/znicholls/CMIP-branded-variable-mapper) with input data as defined in [this spreadsheet](https://docs.google.com/spreadsheets/d/1VBIcauiQPZEN1wdkOLpwBDCCh46QavWzQi7D2aDKK_8/edit), columns DK, DL, DN | Variable registry |


### PR DESCRIPTION
First version of content provenance - missing a few sources and possibly missing other items we should list a source for. Have tried to add where we will source information for the next version (assuming an early CV version is ready) 